### PR TITLE
Implement ORA immediate opcode (0x09) and various fixes

### DIFF
--- a/core.v
+++ b/core.v
@@ -74,10 +74,11 @@ wire im_addr = (op[3:0] == 4'h9 && !op[4]); // immediate addressing?
 
 // routing logic
 
-wire [7:0] A_mux, PC_mux, X_mux, Y_mux;
+wire [15:0] PC_mux;
+wire [7:0] A_mux, X_mux, Y_mux;
 
 assign PC_mux =
-	PC_inc ? PC+1 :
+	PC_inc ? PC + 1 :
 	PC;
 
 assign RW = 1;

--- a/core.v
+++ b/core.v
@@ -64,12 +64,13 @@ wire PC_inc     = AD_from_PC;
 
 wire [7:0] op = decode ? D_in : 8'bX;
 
-wire NOP     = (op == 8'hEA);
-wire LDA_im  = (op == 8'hA9);
-wire ADC_im  = (op == 8'h69);
+wire ORA_im  = (op == 8'h09);
 wire AND_im  = (op == 8'h29);
+wire ADC_im  = (op == 8'h69);
+wire LDA_im  = (op == 8'hA9);
+wire NOP     = (op == 8'hEA);
 
-wire im_addr = (op[3:0] == 4'h9 && !op[4]); // immediate addressing?
+wire im_addr = (op[3:0] == 4'h9 && !op[4]); // immediate addressing ?
 
 
 // routing logic
@@ -119,6 +120,7 @@ always @(posedge clk) begin
 
 	ALU_add    <= 0;
 	ALU_and    <= 0;
+	ALU_or     <= 0;
 
 	if (fetch)
 		decode <= 1;
@@ -131,9 +133,6 @@ always @(posedge clk) begin
 			fetch <= 1;
 		end
 
-		if (LDA_im)
-			A_from_D <= 1;
-
 		if (ADC_im) begin
 			A_from_ALU <= 1;
 			ALU_add    <= 1;
@@ -142,6 +141,14 @@ always @(posedge clk) begin
 		if (AND_im) begin
 			A_from_ALU <= 1;
 			ALU_and    <= 1;
+		end
+
+		if (LDA_im)
+			A_from_D <= 1;
+
+		if (ORA_im) begin
+			A_from_ALU <= 1;
+			ALU_or     <= 1;
 		end
 	end
 

--- a/core.v
+++ b/core.v
@@ -30,13 +30,15 @@ wire [7:0] ALU_C;
 
 reg ALU_add = 0;
 reg ALU_and = 0;
+reg ALU_or  = 0;
 
 alu ALU (
 	.A (ALU_A),
 	.B (ALU_B),
 	.C (ALU_C),
 	.op_add (ALU_add),
-	.op_and (ALU_and)
+	.op_and (ALU_and),
+	.op_or  (ALU_or),
 );
 
 

--- a/core.v
+++ b/core.v
@@ -38,7 +38,7 @@ alu ALU (
 	.C (ALU_C),
 	.op_add (ALU_add),
 	.op_and (ALU_and),
-	.op_or  (ALU_or),
+	.op_or  (ALU_or)
 );
 
 

--- a/core_tb.v
+++ b/core_tb.v
@@ -11,7 +11,7 @@ wire [15:0] AD;
 wire [7:0]  D_in;
 wire [7:0]  D_out;
 
-wire [15:0] A;
+wire [9:0] A;
 
 core CPU (
 	.clk   (clk),
@@ -21,8 +21,8 @@ core CPU (
 	.D_out (D_out)
 );
 
-// only wire up the low 10-bits of AD
-assign A = {6'b0, AD[9:0]};
+// only wire up the low 10-bits of AD to A
+assign A = AD[9:0];
 
 ram RAM (
 	.clk   (clk),

--- a/core_tb.v
+++ b/core_tb.v
@@ -21,7 +21,7 @@ core CPU (
 	.D_out (D_out)
 );
 
-// only wire up the low 10-bits of AD to A
+// only wire up the low 10-bits of AD
 assign A = AD[9:0];
 
 ram RAM (
@@ -51,6 +51,8 @@ initial begin
 	RAM.mem[4] = 8'h03;
 	RAM.mem[5] = 8'h29; // AND #F0
 	RAM.mem[6] = 8'hF0;
+	RAM.mem[7] = 8'h09; // ORA #05
+	RAM.mem[8] = 8'h05;
 
 	#1000 $finish;
 end

--- a/ram.v
+++ b/ram.v
@@ -14,8 +14,8 @@ reg [7:0] mem [SIZE-1:0];
 
 always @(posedge clk)
 	if (RW)
-		D_out  <= mem[A];
+		D_out  <= mem[A[9:0]];
 	else
-		mem[A] <= D_in;
+		mem[A[9:0]] <= D_in;
 
 endmodule

--- a/ram.v
+++ b/ram.v
@@ -5,7 +5,7 @@ module ram
 (
 	input  wire        clk,
 	input  wire        RW,
-// only wire up the low 10-bits of AD
+// only wire up the low 10-bits of A
 	input  wire [9:0]  A,
 	input  wire [7:0]  D_in,
 	output reg  [7:0]  D_out

--- a/ram.v
+++ b/ram.v
@@ -5,7 +5,8 @@ module ram
 (
 	input  wire        clk,
 	input  wire        RW,
-	input  wire [15:0] A,
+// only wire up the low 10-bits of AD
+	input  wire [9:0]  A,
 	input  wire [7:0]  D_in,
 	output reg  [7:0]  D_out
 );
@@ -14,8 +15,8 @@ reg [7:0] mem [SIZE-1:0];
 
 always @(posedge clk)
 	if (RW)
-		D_out  <= mem[A[9:0]];
+		D_out  <= mem[A];
 	else
-		mem[A[9:0]] <= D_in;
+		mem[A] <= D_in;
 
 endmodule


### PR DESCRIPTION
- Completed previous work-in-progress for ORA instruction
- Ensured RAM address "A" wire is 10-bits wide consistently
- PC_mux should be 16-bits wide