### PR TITLE
Added Verilator support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
+# make all       # new: use verilator to produce "core_tb.vcd" output
+#
+# make gtkwave   # new: complete build, run and display "core_tb.vcd" output
+#
+# make iverilog  # old: use iverilog to produce "core_tb.vcd" output
+
 all: core_tb.vcd
 
-core_tb.vvp: core_tb.v core.v ram.v
+gtkwave: core_tb.vcd
+	gtkwave core_tb.gtkw  # key signals already selected for display
+
+core_tb.vcd: core_tb.cpp alu.v core.v core_tb.v ram.v
+	verilator -Wall --exe --build -j core_tb.v -cc core_tb.cpp --trace-fst
+	./obj_dir/Vcore_tb
+
+core_tb.vvp: alu.v core.v core_tb.v ram.v
 	iverilog -o core_tb.vvp core_tb.v core.v alu.v ram.v
 
-core_tb.vcd: core_tb.vvp
+iverilog: core_tb.vvp
 	vvp core_tb.vvp
 
 clean:
-	rm -rf core_tb.vvp core_tb.vcd
+	rm -rf core_tb.vvp core_tb.vcd obj_dir
 
 .PHONY: all clean

--- a/alu.v
+++ b/alu.v
@@ -1,3 +1,5 @@
+`timescale 100ns / 1ns
+
 module alu
 (
 	input  wire [7:0] A,

--- a/core.v
+++ b/core.v
@@ -1,3 +1,5 @@
+`timescale 100ns / 1ns
+
 module core
 (
 	input  wire        clk,
@@ -18,8 +20,8 @@ reg  [7:0] Y;
 reg  [7:0] S;
 reg  [7:0] P;
 
-wire [7:0] PCL = PC[7:0];
-wire [7:0] PCH = PC[15:8];
+// wire [7:0] PCL = PC[7:0];
+// wire [7:0] PCH = PC[15:8];
 
 
 // ALU
@@ -48,7 +50,7 @@ reg fetch  = 1; // instruction fetch
 reg decode = 0; // instruction decode
 reg exec   = 0; // execution
 
-wire bork  = !(fetch || decode || exec); // for debug
+// wire bork  = !(fetch || decode || exec); // for debug
 
 
 // control signals

--- a/core_tb.cpp
+++ b/core_tb.cpp
@@ -1,0 +1,39 @@
+/*
+ * Usage
+ * ~~~~~
+ * verilator -V | grep VERILATOR_ROOT
+ *   VERILATOR_ROOT=/home/pi/play/fpga/oss-cad-suite/share/verilator
+ * verilator -Wall --exe --build -j core_tb.v -cc core_tb.cpp --trace-fst
+ * ./obj_dir/Vcore_tb
+ *
+ * To Do
+ * ~~~~~
+ * - Command line argument to enable / disable VL_PRINTF()
+ * - Command line argument for maximum clock cycles to run
+ */
+
+#include <stdlib.h>
+#include "verilated_fst_c.h"  // "verilated.h" and "--trace"
+
+#include "Vcore_tb.h"
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+  Verilated::debug(0);  // 0 - 9
+  Verilated::traceEverOn(true);  // required for "--trace" or "--trace-fst"
+
+  Vcore_tb *core_tb = new Vcore_tb;
+
+  int counter = 0;
+  while (! Verilated::gotFinish()  &&  ++ counter <= 100) {
+    core_tb->clk = ! core_tb->clk;
+    core_tb->eval();
+
+    VL_PRINTF("[%" VL_PRI64 "d] clk=%x\n", Verilated::time(), core_tb->clk);
+    Verilated::timeInc(1);
+  }
+
+  core_tb->final();
+  delete core_tb;
+  return(0);
+}

--- a/core_tb.gtkw
+++ b/core_tb.gtkw
@@ -1,0 +1,27 @@
+[*]
+[*] GTKWave Analyzer v3.3.110 (w)1999-2020 BSI
+[*]
+[dumpfile] "core_tb.vcd"
+[savefile] "core_tb.gtkw"
+[timestart] 0
+[size] 1910 600
+[pos] -1 -1
+*-3.030324 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] TOP.
+[treeopen] TOP.core_tb.
+[sst_width] 284
+[signals_width] 102
+[sst_expanded] 1
+[sst_vpaned_height] 156
+@28
+TOP.core_tb.CPU.clk
+TOP.core_tb.CPU.fetch
+TOP.core_tb.CPU.decode
+TOP.core_tb.CPU.exec
+@22
+TOP.core_tb.CPU.PC[15:0]
+TOP.core_tb.CPU.D_in[7:0]
+@23
+TOP.core_tb.CPU.A[7:0]
+[pattern_trace] 1
+[pattern_trace] 0

--- a/core_tb.v
+++ b/core_tb.v
@@ -1,17 +1,15 @@
-`timescale 1ns / 10ps
+`timescale 100ns / 1ns
 
-module core_tb;
+module core_tb(input clk);
 
 integer i;
 
-reg clk = 0;
+// reg clk = 0;
 
 wire RW;
 wire [15:0] AD;
 wire [7:0]  D_in;
 wire [7:0]  D_out;
-
-wire [9:0] A;
 
 core CPU (
 	.clk   (clk),
@@ -21,19 +19,16 @@ core CPU (
 	.D_out (D_out)
 );
 
-// only wire up the low 10-bits of AD
-assign A = AD[9:0];
-
 ram RAM (
 	.clk   (clk),
 	.RW    (RW),
-	.A     (A),
+	.AD    (AD),
 	.D_in  (D_out),
 	.D_out (D_in)
 );
 
 
-always #5 clk = ~clk;
+// always clk = ~clk;
 
 initial begin
 	$dumpfile("core_tb.vcd");
@@ -53,8 +48,6 @@ initial begin
 	RAM.mem[6] = 8'hF0;
 	RAM.mem[7] = 8'h09; // ORA #05
 	RAM.mem[8] = 8'h05;
-
-	#1000 $finish;
 end
 
 endmodule

--- a/ram.v
+++ b/ram.v
@@ -1,3 +1,5 @@
+`timescale 100ns / 1ns
+
 module ram
 #(
 	parameter SIZE = 1024
@@ -5,8 +7,7 @@ module ram
 (
 	input  wire        clk,
 	input  wire        RW,
-// only wire up the low 10-bits of A
-	input  wire [9:0]  A,
+	input  wire [15:0] AD,
 	input  wire [7:0]  D_in,
 	output reg  [7:0]  D_out
 );
@@ -15,8 +16,12 @@ reg [7:0] mem [SIZE-1:0];
 
 always @(posedge clk)
 	if (RW)
-		D_out  <= mem[A];
+		D_out  <= mem[AD[9:0]];
 	else
-		mem[A] <= D_in;
+		mem[AD[9:0]] <= D_in;
+
+initial begin
+	mem[SIZE-1] = AD[15:8];  // Stop Verilator complaining about used bits
+end
 
 endmodule


### PR DESCRIPTION
All of the Verilog changes were required to get Verilator working without compilation errors or warnings.

Verilog "core_tb.v" changed for Verilator and source code required for iverilog commented out (mostly to do with
"clk").  iverilog won't work now, i.e won't produce "clk" signals without the "clk" source being uncommented again.  Primarily means that GTKWave won't display any waveforms.